### PR TITLE
fix: DanielOnDiordna/player-tracker-addon.yml downloadURL

### DIFF
--- a/metadata/DanielOnDiordna/player-tracker-addon.yml
+++ b/metadata/DanielOnDiordna/player-tracker-addon.yml
@@ -1,2 +1,2 @@
 updateURL: https://softspot.nl/ingress/plugins/iitc-plugin-player-tracker-addon.meta.js
-downloadURL: https://softspot.nl/ingress/plugins/iitc-plugin-player-tracker-addon.meta.js
+downloadURL: https://softspot.nl/ingress/plugins/iitc-plugin-player-tracker-addon.user.js


### PR DESCRIPTION
The download URL was pointing to the meta.js
Fixes #27 