### PR TITLE
fix: Perringaiden/fielded-link-radius URLs

### DIFF
--- a/metadata/Perringaiden/wolf-fielded-link-radius.yml
+++ b/metadata/Perringaiden/wolf-fielded-link-radius.yml
@@ -1,3 +1,3 @@
-updateURL: https://bitbucket.org/perringaiden/iitc/raw/master/iitc-plugin-wolf-deployed-highlighter.user.js
-downloadURL: https://bitbucket.org/perringaiden/iitc/raw/master/iitc-plugin-wolf-deployed-highlighter.user.js
+updateURL: https://bitbucket.org/perringaiden/iitc/raw/master/iitc-plugin-wolf-fielded-link-radius.user.js
+downloadURL: https://bitbucket.org/perringaiden/iitc/raw/master/iitc-plugin-wolf-fielded-link-radius.user.js
 author: Perringaiden


### PR DESCRIPTION
The download and update URLs where set to the deployed-highlighter plugin.