### PR TITLE
Add my almost-8 highlighter

### DIFF
--- a/metadata/Artoria2e5/highlight-7miss1.yml
+++ b/metadata/Artoria2e5/highlight-7miss1.yml
@@ -1,0 +1,4 @@
+updateURL: https://raw.githubusercontent.com/Artoria2e5/misc/master/ingress/highlight-7miss1.js
+downloadURL: https://raw.githubusercontent.com/Artoria2e5/misc/master/ingress/highlight-7miss1.js
+antiFeatures:
+  - scraper


### PR DESCRIPTION
Some people like to help raise portals to level 8 -- you've probably heard about people who go out of their ways to add the last L8 resonator. This plugin is for them: it highlights portals that are 1, 2, or 3 L8-resonators to level 8.

Here's a look on Washington DC:
![Screenshot 2024-06-04 at 12-16-02 Ingress Intel Map-or8](https://github.com/Artoria2e5/misc/assets/6459309/5b37bece-2050-48ea-a3b3-585a6971f0e0)

The 1res-to-8 portals are purple, the 2-to-8 ones are magenta, and the 3-to-8 ones are yellow. There's also a feature that colors almost-8 portals with the player's L8 resonator(s) grey, but as I'm not in the US, this example includes none of them.

(Why not just 1, but 1,2,3? Well, I figured that people might want to meet and eat. Now 3 agents are enough to make a 7, but a L8 meal-portal is even better.)

* * *
Anti-pattern: scraper. Portal details are requested to get full resonator deployment status.
* I try to reduce the number of requests through pre-filtering and aggressive use of the vanilla detail cache.
* Request is rate-limited to once per 20ms; that seems sufficient for minimizing 502 errors. Errors are retried using a queue.