### PR TITLE
added Mediagress plugin

### DIFF
--- a/metadata/IngressPlus/mediagress.yml
+++ b/metadata/IngressPlus/mediagress.yml
@@ -1,0 +1,8 @@
+updateURL: https://ingress.plus/mediagress.user.js
+downloadURL: https://ingress.plus/mediagress.user.js
+preview: https://ingress.plus/images/mediagress_upload.jpg
+issueTracker: https://github.com/dedo1911/ingress-plus/issues
+homepageURL: https://ingress.plus/media
+author: IngressPlus
+antiFeatures:
+  - export


### PR DESCRIPTION
Added the Mediagress plugin to enable C.O.R.E. users to upload their Media items to Mediagress at [ingress.plus/media](https://ingress.plus/media). Anti-Feature "export" as it exports and sends the inventory data of Media to a third party website.

(this time correctly hopefully, apologies ^^')