### PR TITLE
Fix Glympse plugin preview image CORS issue

### DIFF
--- a/metadata/MaxEtMoritz/glympsemap.yml
+++ b/metadata/MaxEtMoritz/glympsemap.yml
@@ -1,5 +1,5 @@
 updateURL: https://github.com/MaxEtMoritz/iitc-glympse/raw/master/iitc-glympsemap.user.js
 downloadURL: https://github.com/MaxEtMoritz/iitc-glympse/raw/master/iitc-glympsemap.user.js
-preview: https://github.com/MaxEtMoritz/iitc-glympse/blob/master/images/Screenshot%202022-08-12%20163456.png
+preview: https://raw.githubusercontent.com/MaxEtMoritz/iitc-glympse/master/images/Screenshot%202022-08-12%20163456.png
 issueTracker: https://github.com/MaxEtMoritz/iitc-glympse/issues
 homepageURL: https://github.com/MaxEtMoritz/iitc-glympse


### PR DESCRIPTION
The old link did not display the preview image correctly on the IITC homepage due to CORS issues.
The new link works fine.