### PR TITLE
Create Microfield-checker.yml

### DIFF
--- a/metadata/Xelminoe/Microfield-checker.yml
+++ b/metadata/Xelminoe/Microfield-checker.yml
@@ -1,0 +1,6 @@
+downloadURL:  https://raw.github.com/Xelminoe/Microfield-Checker/main/Microfield-Checker.user.js
+updateURL:  https://raw.github.com/Xelminoe/Microfield-Checker/main/Microfield-Checker.user.js
+depends: draw-tools@breunigs
+recommends:  keepalldata@DanielOnDiordna
+preview:  https://raw.github.com/Xelminoe/Microfield-Checker/main/images/example00.jpg
+issueTracker: https://github.com/Xelminoe/Microfield-Checker/issues


### PR DESCRIPTION
This PR adds a new plugin called Microfield Checker, which analyzes optimal microfield nesting within a triangle defined by three drawn markers, and highlights missing nested fields (lost to wrong linking order).

Thank you for maintaining the community plugin catalog!
