### PR TITLE
New plugin VRBB L8 Maximizer

### DIFF
--- a/metadata/Xelminoe/VRBB-l8-maximizer.yml
+++ b/metadata/Xelminoe/VRBB-l8-maximizer.yml
@@ -1,3 +1,4 @@
 downloadURL: https://raw.github.com/Xelminoe/VRBB-L8-Maximizer/main/VRBB-L8-Maximizer.user.js
 updateURL: https://raw.github.com/Xelminoe/VRBB-L8-Maximizer/main/VRBB-L8-Maximizer.user.js
 homepageURL: https://xelminoe.github.io/VRBB-L8-Maximizer/
+issueTracker: https://github.com/Xelminoe/VRBB-L8-Maximizer/issues


### PR DESCRIPTION
This PR adds a new plugin called VRBB L8 Maximizer, which assists planning L8 resonator max-out using a very rare battle beacon (VRBB) — e.g. 3 agents from the same side build an L8 portal in 15 minutes.

Thank you for maintaining the community plugin catalog!