### PR TITLE
Added IITC Plugin Portal Route

### DIFF
--- a/metadata/MikeDiehn/portal-route.yml
+++ b/metadata/MikeDiehn/portal-route.yml
@@ -1,0 +1,6 @@
+updateURL: https://raw.githubusercontent.com/mdiehn/iitc-plugin-portal-route/refs/heads/main/dist/portal-route.meta.js
+downloadURL: https://raw.githubusercontent.com/mdiehn/iitc-plugin-portal-route/refs/heads/main/dist/portal-route.user.js
+issueTracker: https://github.com/mdiehn/iitc-plugins/portal-route/issues
+author: Mike Diehn
+match:
+  - https://intel.ingress.com/*

--- a/metadata/MikeDiehn/portal-route.yml
+++ b/metadata/MikeDiehn/portal-route.yml
@@ -1,6 +1,2 @@
 updateURL: https://raw.githubusercontent.com/mdiehn/iitc-plugin-portal-route/refs/heads/main/dist/portal-route.meta.js
 downloadURL: https://raw.githubusercontent.com/mdiehn/iitc-plugin-portal-route/refs/heads/main/dist/portal-route.user.js
-issueTracker: https://github.com/mdiehn/iitc-plugins/portal-route/issues
-author: Mike Diehn
-match:
-  - https://intel.ingress.com/*


### PR DESCRIPTION
Portal Route is an IITC plugin for planning a route through selected Ingress portals.  It is built for mobile-first use, but works on desktop IITC too. Pick portals, keep them in order, plot the route, track stop time, and send the route to Google Maps when you are ready. It will also let you export and import routes and print the list of waypoints.