### PR TITLE
Add Follow Mode plugin

### DIFF
--- a/metadata/MikeDiehn/follow-mode.yml
+++ b/metadata/MikeDiehn/follow-mode.yml
@@ -1,0 +1,2 @@
+updateURL:     https://raw.githubusercontent.com/mdiehn/iitc-plugin-follow-mode/refs/heads/main/dist/follow-mode.meta.js
+downloadURL:   https://raw.githubusercontent.com/mdiehn/iitc-plugin-follow-mode/refs/heads/main/dist/follow-mode.user.js


### PR DESCRIPTION
## Summary

Add Follow Mode, an IITC add-on that improves user-location following with
smoother camera movement, optional heading-up map rotation, viewport bias,
and an on-map reticle control for quick follow toggling.

This is the first general release of the plugin.

## User-visible behavior

- Adds a Follow Mode reticle control on the map
- Smoothly follows IITC user-location updates
- Optionally rotates the map heading-up
- Biases the viewport to show more map ahead of travel
- Adds a Follow Mode Opt dialog for tuning behavior
- Keeps ahead portal loading disabled by default

## Notes

Ahead portal loading is included as an experimental option, but remains off
by default. When enabled, it can make extra Intel map-data requests, so the
README documents that it should be used conservatively.

## Checks

- `npm run check`