### PR TITLE
Add Anchor Planner by emgeka

### DIFF
--- a/metadata/emgeka/anchor-planner.yml
+++ b/metadata/emgeka/anchor-planner.yml
@@ -1,0 +1,11 @@
+updateURL: https://raw.githubusercontent.com/emgeka/iitc-anchor-planner/main/releases/iitc-anchor-planner.user.js
+downloadURL: https://raw.githubusercontent.com/emgeka/iitc-anchor-planner/main/releases/iitc-anchor-planner.user.js
+homepageURL: https://github.com/emgeka/iitc-anchor-planner
+issueTracker: https://github.com/emgeka/iitc-anchor-planner/issues
+depends:
+  - draw-tools@breunigs
+recommends:
+  - bookmarks@ZasoGD
+antiFeatures:
+  - scraper
+  - export


### PR DESCRIPTION
## Plugin

Adds **Anchor Planner** by `emgeka` to the IITC Community Plugins catalog.

Anchor Planner scans Draw Tools and Auto Draw link plans, resolves plan portals from loaded IITC portals and bookmarks, calculates key requirements, identifies currently loaded blocking links, provides route and navigation support, and exports the plan as text or JSON.

## Metadata

- Requires `draw-tools@breunigs`.
- Recommends `bookmarks@ZasoGD`.
- Declares `scraper` because missing portal names can be requested automatically.
- Declares `export` because plan and portal data can be exported by the user.
- Uses a stable, publicly accessible userscript URL from the plugin repository.

## Validation

- Source release 0.1.41 was tested in IITC on desktop and mobile.
- Community metadata generation completed successfully with `lib-iitc-manager`.
- Generated community userscript passes JavaScript syntax checking.
- The PR contains only `metadata/emgeka/anchor-planner.yml`.
