### PR TITLE
feat(tools): add plugin patching mechanism

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Patches match the plugin source byte for byte, any line ending conversion breaks them
+patches/**/*.patch -text

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -27,6 +27,10 @@ jobs:
         run: npm install
         working-directory: ./tools
 
+      - name: Test
+        run: npm test
+        working-directory: ./tools
+
       - name: Check PR
         id: run-check-pr
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tools/node_modules/
 /tools/package-lock.json
+/patches/.work/
 /.idea/
 /.vscode/
 check_pr_output

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,12 @@ You only need to make sure the plugin is always available to our catalog build s
 - In `metadata` folder, create a folder with the name of plugin's author.
 - Inside create a file `[filename].yml`. For example, `minimap.yml`.
 - Then, using YAML syntax, describe at least 2 mandatory fields: `updateURL` and `downloadURL`. Example:
+
 ```yaml
 updateURL: https://iitc.app/build/release/plugins/cache-portals-on-map.meta.js
 downloadURL: https://iitc.app/build/release/plugins/cache-portals-on-map.user.js
 ```
+
 - You can also overwrite values from the "==UserScript==" blocks or add new values. See [Possible key types](#possible-key-types).
 - Make sure that your plugin does not use features that could be dangerous to the user. Otherwise you need to specify them in the `antiFeatures` key. See [Anti-features](#anti-features).
 - Make a commit and send a PR with the changes to this repository.
@@ -26,27 +28,27 @@ downloadURL: https://iitc.app/build/release/plugins/cache-portals-on-map.user.js
 
 Mandatory:
 
-* `updateURL`
-* `downloadURL`
+- `updateURL`
+- `downloadURL`
 
 Conditional:
 
-* `name` - Usually plugins have the `name` key in the "==UserScript==" block. If your plugin does not have this key, it must be specified.
-* `antiFeatures` - If your plugin uses dangerous features, you should list them. [Anti-features](#anti-features).
+- `name` - Usually plugins have the `name` key in the "==UserScript==" block. If your plugin does not have this key, it must be specified.
+- `antiFeatures` - If your plugin uses dangerous features, you should list them. [Anti-features](#anti-features).
 
 Optional:
 
-* `preview` - A preview image for your plugin.
-* `issueTracker` - Link to issue tracker of plugin. (automatically generated if `downloadURL` points to GitHub or GitLab)
-* `depends` - List of plugins required for your plugin to work. As values, specify the `id` of the required plugins.
-* `recommends` - List of plugins recommended for your plugin to work. As values, specify the `id` of the recommended plugins.
-* `skipMatchCheck` - Set to "true" if the plugin is not intended to run on intel/missions sites.
+- `preview` - A preview image for your plugin.
+- `issueTracker` - Link to issue tracker of plugin. (automatically generated if `downloadURL` points to GitHub or GitLab)
+- `depends` - List of plugins required for your plugin to work. As values, specify the `id` of the required plugins.
+- `recommends` - List of plugins recommended for your plugin to work. As values, specify the `id` of the recommended plugins.
+- `skipMatchCheck` - Set to "true" if the plugin is not intended to run on intel/missions sites.
 
 You can also override or add keys frequently used in the "==UserScript==" block:
 
-* `homepageURL` (automatically generated if `downloadURL` points to GitHub or GitLab)
-* `match`
-* `include`
+- `homepageURL` (automatically generated if `downloadURL` points to GitHub or GitLab)
+- `match`
+- `include`
 
 etc...
 
@@ -57,14 +59,14 @@ To some extent it is a violation of the rules, but it is a popular tool and does
 This is partly because IITC behaves like a stock Ingress Intel map and tries not to violate ToS.
 
 Nevertheless, some third-party plugins may be more dangerous for the user.
-IITC Store allows to place such plugins in its directory, but it is necessary to specify which dangerous features are used.
+IITC Community plugins allows to place such plugins in its directory, but it is necessary to specify which dangerous features are used.
 This will allow users prepared for the risk of account blocking to use such plugins and protect ordinary users.
 
 List of dangerous features:
 
-* `scraper` - The plugin makes additional requests for more information than is explicitly requested by the user. For example, it infects full information about portals that the user has not clicked on.
-* `highLoad` - The plugin makes many more requests than the usual Intel/IITC use.
-* `export` - The plugin allows you to export Niantic data (excluding debugging purposes).
+- `scraper` - The plugin makes additional requests for more information than is explicitly requested by the user. For example, it infects full information about portals that the user has not clicked on.
+- `highLoad` - The plugin makes many more requests than the usual Intel/IITC use.
+- `export` - The plugin allows you to export Niantic data (excluding debugging purposes).
 
 ### Example of using multiple keys
 
@@ -81,3 +83,17 @@ author: JohnSmith
 match:
   - https://intel.ingress.com/*
 ```
+
+## Patches
+
+Some plugins need a small fix to keep working, for example because of an API removed from a library that IITC ships, while their author no longer responds.
+For those the catalog can carry a patch: a diff stored in [patches](/patches) and applied to the plugin source before it is published.
+
+A patch is appropriate when the fix is small and mechanical and the author was told about the problem but did not react.
+It is not a way to add features or to rewrite a plugin, fork it and point `downloadURL` at your fork instead.
+Report the problem to the author first and link that issue in the patch, even if the repository looks abandoned.
+
+Patched plugins are marked as such: a `patch` key in `dist/meta.json`, a `patch` line in the "==UserScript==" block and a note in README.md.
+The patch date is appended to the version of the author, so that userscript managers see the update.
+
+See [patches/README.md](/patches/README.md) for how to create one.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,56 @@
+# Patches
+
+A patch is a unified diff applied to the plugin source downloaded from its author, before it is published to `dist`.
+See [Patches](/CONTRIBUTING.md#patches) for when this is appropriate.
+
+One patch per plugin, named after its metadata file: `metadata/Zaso/player-ranges.yml` -> `patches/Zaso/player-ranges.patch`.
+
+## Creating and updating a patch
+
+```
+cd tools
+npm run patch:start -- Zaso/player-ranges
+```
+
+This downloads the plugin into `patches/.work/Zaso/player-ranges`: `a.user.js` is the pristine source, `b.user.js` is the copy to edit.
+Make the smallest change that fixes the problem in `b.user.js`, leave `a.user.js` untouched, then:
+
+```
+npm run patch:save -- Zaso/player-ranges --reason='jQuery 4 removed $.isNumeric()' --upstream=https://github.com/author/repo/issues/42
+```
+
+The same two commands update an existing patch. `b.user.js` then already contains it, and `--reason` and `--upstream` are taken from the current patch when omitted.
+
+## Preamble
+
+`patch:save` writes the headers of the patch, there is no need to edit them by hand:
+
+- `Reason` - why the patch exists. Ends up in `dist/meta.json`, in IITC Community plugins and in README.md.
+- `Upstream` - link to the issue reported to the author. Optional, but a patch is not a replacement for telling the author.
+- `Created-For-Version` - the version the patch was written against. A patch that still applies to a newer version is reported as possibly obsolete.
+- `Patch-Date` - the timestamp appended to the published version.
+
+## Versioning
+
+Userscript managers only offer an update when the version changes, and a patch does not change the version of the author.
+So a patched plugin is published under the upstream version with the patch date appended:
+
+```
+0.3.1  ->  0.3.1.20260727.104500
+```
+
+That version is also what tells the build system whether the plugin has to be republished, so a patch changed without its `Patch-Date` being bumped has no effect at all.
+
+## Rules
+
+- Never edit `dist` by hand, it is regenerated from the source of the author on every build.
+- A patch must not change the "==UserScript==" block, use `metadata/<author>/<plugin>.yml` for metadata.
+- Keep the patch minimal, it has to survive the author releasing new versions.
+- Do not edit a patch by hand, run the two commands again instead. Its context is compared byte for byte, and an editor that trims trailing whitespace on save is enough to break it.
+
+## When a patch stops applying
+
+The context has to match exactly, so the patch stops applying as soon as the author touches the patched code.
+The plugin is then published unpatched, with a warning in the build log and in the comment of the pull request.
+
+Check whether the fix is still needed. If it is, create the patch again; if the author fixed the problem, delete `patches/<author>/<plugin>.patch` and the plugin gets published as is.

--- a/tools/check-pr.js
+++ b/tools/check-pr.js
@@ -1,7 +1,8 @@
 import {run_update} from './actions.js';
 import {exec} from 'child_process';
 import fs from 'fs';
-import {check_duplicate_plugins, ext} from './helpers.js';
+import {parseMeta} from 'lib-iitc-manager';
+import {check_duplicate_plugins, ext, patch_stamp, patch_warnings, read_patch} from './helpers.js';
 
 const proc = await exec('git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master)');
 
@@ -13,20 +14,50 @@ proc.stdout.on('data', (chunk) => {
 proc.on('exit', async () => {
     updated_files = updated_files.split('\n');
 
-    const metadata_files = [];
+    const metadata_files = new Map();
+    const changed_patches = new Set();
     for (const file of updated_files) {
-        if (file.startsWith('metadata/')) {
-            const [, author, filename] = file.split('/');
-            metadata_files.push(['../' + file, author, filename]);
+        const [dir, author, name] = file.split('/');
+        if (name === undefined) continue;
+
+        let filename = null;
+        if (dir === 'metadata' && name.endsWith('.yml')) filename = name;
+        if (dir === 'patches' && name.endsWith('.patch')) filename = name.replace(/\.patch$/, '.yml');
+        if (filename === null) continue;
+
+        metadata_files.set(`${author}/${filename}`, [`../metadata/${author}/${filename}`, author, filename]);
+        if (dir === 'patches') changed_patches.add(`${author}/${filename}`);
+    }
+
+    // A patch that changed without its Patch-Date being bumped keeps the version the plugin
+    // is already published under, so nothing would be republished.
+    const warnings = [];
+    for (const key of changed_patches) {
+        const [author, filename] = key.split('/');
+        const patch = read_patch(author, filename);
+        const dist_meta_path = `../dist/${author}/${ext(filename, 'meta')}`;
+        if (patch === null || !fs.existsSync(dist_meta_path)) continue;
+
+        const dist_meta = parseMeta(fs.readFileSync(dist_meta_path, 'utf8'));
+        if (dist_meta !== null && dist_meta.version.endsWith(`.${patch_stamp(patch.headers)}`)) {
+            warnings.push({
+                path: `patches/${author}/${filename.replace(/\.yml$/, '.patch')}`,
+                message: 'the patch was changed but its Patch-Date was not, so the plugin will not be republished'
+            });
         }
     }
-    const is_updated = await run_update(metadata_files);
-    check_duplicate_plugins();
 
-    let message = "";
+    const is_updated = await run_update([...metadata_files.values()]);
+    check_duplicate_plugins();
+    warnings.push(...patch_warnings);
+
+    let message = '';
+    if (warnings.length > 0) {
+        message += `> [!WARNING]\n${warnings.map(({path, message}) => `> **${path}**: ${message}`).join('\n')}\n\n`;
+    }
     if (is_updated) {
-        message = '### Changes are detected:\n';
-        for (const [, author, filename] of metadata_files) {
+        message += '### Changes are detected:\n';
+        for (const [, author, filename] of metadata_files.values()) {
             try {
                 const meta = fs.readFileSync(`../dist/${author}/${ext(filename, 'meta')}`, 'utf8');
                 message += `**${author}/${ext(filename, 'meta')}**\n\`\`\`\n${meta}\n\`\`\`\n---\n`;
@@ -35,7 +66,7 @@ proc.on('exit', async () => {
             }
         }
     } else {
-        message = '### No changes are detected';
+        message += '### No changes are detected';
     }
 
     console.log(message);

--- a/tools/helpers.js
+++ b/tools/helpers.js
@@ -81,6 +81,15 @@ export const ext = (filename, prefix) => {
     return filename.replace(/.yml$/, `.${prefix}.js`);
 };
 
+/**
+ * Converts the line endings of the plugin source code to LF, so that everything
+ * published uses the same ones no matter what the author writes with.
+ *
+ * @param {string} plugin_js - Plugin source code.
+ * @return {string}
+ */
+export const normalize_eol = (plugin_js) => plugin_js.replace(/\r\n?/g, '\n');
+
 export const is_plugin_update_available = async (metadata, author, filename) => {
     const source_meta_js = await fetchData(metadata.updateURL);
     if (source_meta_js === null) throw new Error(`${metadata.updateURL} is not a valid URL`);
@@ -150,9 +159,10 @@ const prepare_meta_js = (meta) => {
 };
 
 export const update_plugin = async (metadata, author, filename) => {
-    const source_plugin_js = await fetchData(metadata.downloadURL);
-    if (source_plugin_js === null) throw new Error(`${metadata.downloadURL} is not a valid URL`);
+    const downloaded_plugin_js = await fetchData(metadata.downloadURL);
+    if (downloaded_plugin_js === null) throw new Error(`${metadata.downloadURL} is not a valid URL`);
 
+    const source_plugin_js = normalize_eol(downloaded_plugin_js);
     const source_meta = parseMeta(source_plugin_js);
     if (source_meta === null) throw new Error(`${metadata.downloadURL} is not a valid metadata file`);
 

--- a/tools/helpers.js
+++ b/tools/helpers.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import {execFileSync} from 'child_process';
+import {applyPatch} from 'diff';
 import YAML from 'yaml';
 import {fetchData, checkMetaMatchPattern, parseMeta} from 'lib-iitc-manager';
 
@@ -89,6 +90,122 @@ export const ext = (filename, prefix) => {
  * @return {string}
  */
 export const normalize_eol = (plugin_js) => plugin_js.replace(/\r\n?/g, '\n');
+
+const PATCH_HEADER_RE = /^#\s*([A-Za-z][A-Za-z-]*)\s*:\s*(.*)$/;
+const PATCH_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})Z?$/;
+const REQUIRED_PATCH_HEADERS = {reason: 'Reason', createdForVersion: 'Created-For-Version', patchDate: 'Patch-Date'};
+
+/**
+ * Warnings collected while applying patches, as {path, message} objects.
+ * Also printed as GitHub workflow annotations, see warn_patch().
+ *
+ * @type {Array.<Object<string, string>>}
+ */
+export const patch_warnings = [];
+
+/**
+ * Builds the version stamp appended to the version of a patched plugin.
+ *
+ * @param {Object<string, string>} headers - Parsed patch headers.
+ * @return {string} Stamp in the "YYYYMMDD.HHMMSS" form.
+ */
+export const patch_stamp = (headers) => {
+    const match = PATCH_DATE_RE.exec(headers.patchDate);
+    if (match === null) throw new Error(`invalid Patch-Date "${headers.patchDate}", expected "YYYY-MM-DD HH:MM:SS"`);
+
+    const [, year, month, day, hours, minutes, seconds] = match;
+    return `${year}${month}${day}.${hours}${minutes}${seconds}`;
+};
+
+/**
+ * Parses a patch file: a preamble of "# Key: value" comments followed by a unified diff.
+ *
+ * @param {string} text - Contents of the patch file.
+ * @return {{headers: Object<string, string>, diff: string}}
+ */
+export const parse_patch = (text) => {
+    const lines = text.split('\n');
+    const headers = {};
+
+    let diff_start = 0;
+    for (; diff_start < lines.length; diff_start++) {
+        const line = lines[diff_start];
+        if (line.trim() === '') continue;
+        if (!line.startsWith('#')) break;
+
+        const match = PATCH_HEADER_RE.exec(line);
+        if (match === null) throw new Error(`unparsable header line "${line}"`);
+        headers[match[1].toLowerCase().replace(/-(.)/g, (_, char) => char.toUpperCase())] = match[2].trim();
+    }
+
+    for (const [key, name] of Object.entries(REQUIRED_PATCH_HEADERS)) {
+        if (!headers[key]) throw new Error(`missing the required "${name}" header`);
+    }
+    patch_stamp(headers);
+
+    const diff = lines.slice(diff_start).join('\n');
+    if (!/^--- /m.test(diff)) throw new Error('no unified diff found (missing a "--- " line)');
+    if (!/^@@ /m.test(diff)) throw new Error('the diff is empty (no hunks)');
+
+    return {headers, diff};
+};
+
+/**
+ * Applies a patch to the plugin source code.
+ * The context has to match exactly (fuzzFactor: 0): once upstream touches the patched
+ * code the patch stops applying, which is how an obsolete patch is detected.
+ *
+ * @param {string} source - Plugin source code.
+ * @param {{diff: string}} patch - Patch as returned by parse_patch().
+ * @return {{code: string, applied: boolean}}
+ */
+export const apply_patch = (source, patch) => {
+    const code = applyPatch(source, patch.diff, {fuzzFactor: 0});
+    return code === false ? {code: source, applied: false} : {code: code, applied: true};
+};
+
+/**
+ * Builds the version a plugin is published under: the upstream version, stamped
+ * with the patch date when the plugin is patched.
+ *
+ * @param {string} source_version - Version from the upstream metablock.
+ * @param {?{headers: Object<string, string>}} patch - Patch as returned by read_patch(), or null.
+ * @return {string}
+ */
+export const patched_version = (source_version, patch) => {
+    if (patch === null || typeof source_version !== 'string' || source_version === '') return source_version;
+    return `${source_version}.${patch_stamp(patch.headers)}`;
+};
+
+/**
+ * Returns the path to the patch of a plugin, or null when the plugin is not patched.
+ *
+ * @param {string} author - Author name.
+ * @param {string} filename - Name of the metadata file.
+ * @return {?string}
+ */
+export const get_patch_path = (author, filename) => {
+    const patch_path = `../patches/${author}/${filename.replace(/\.yml$/, '.patch')}`;
+    return fs.existsSync(patch_path) ? patch_path : null;
+};
+
+/**
+ * Reads and parses the patch of a plugin.
+ *
+ * @param {string} author - Author name.
+ * @param {string} filename - Name of the metadata file.
+ * @return {?{headers: Object<string, string>, diff: string, path: string}}
+ */
+export const read_patch = (author, filename) => {
+    const patch_path = get_patch_path(author, filename);
+    if (patch_path === null) return null;
+
+    try {
+        return {...parse_patch(fs.readFileSync(patch_path, 'utf8')), path: patch_path};
+    } catch (e) {
+        throw new Error(`${patch_path}: ${e.message}`);
+    }
+};
 
 export const is_plugin_update_available = async (metadata, author, filename) => {
     const source_meta_js = await fetchData(metadata.updateURL);

--- a/tools/helpers.js
+++ b/tools/helpers.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import vm from 'vm';
 import {execFileSync} from 'child_process';
 import {applyPatch} from 'diff';
 import YAML from 'yaml';
@@ -102,6 +103,12 @@ const REQUIRED_PATCH_HEADERS = {reason: 'Reason', createdForVersion: 'Created-Fo
  * @type {Array.<Object<string, string>>}
  */
 export const patch_warnings = [];
+
+const warn_patch = (patch, message) => {
+    const patch_path = path.relative(REPO_DIR, patch.path);
+    patch_warnings.push({path: patch_path, message});
+    console.log(`::warning file=${patch_path}::${message}`);
+};
 
 /**
  * Builds the version stamp appended to the version of a patched plugin.
@@ -214,13 +221,15 @@ export const is_plugin_update_available = async (metadata, author, filename) => 
     const source_meta = parseMeta(source_meta_js);
     if (source_meta === null) throw new Error(`${metadata.updateURL} is not a valid metadata file`);
 
+    const expected_version = patched_version(source_meta.version, read_patch(author, filename));
+
     const dist_meta_path = `../dist/${author}/${ext(filename, 'meta')}`;
     if (await fileExists(dist_meta_path)) {
         const dist_meta_js = fs.readFileSync(dist_meta_path, 'utf8');
         const dist_meta = parseMeta(dist_meta_js);
         if (dist_meta === null) throw new Error(`${dist_meta_path} is not a valid metadata file`);
 
-        if (source_meta.version === dist_meta.version) {
+        if (expected_version === dist_meta.version) {
             return false;
         }
     }
@@ -275,6 +284,37 @@ const prepare_meta_js = (meta) => {
     return meta_js;
 };
 
+const assert_valid_syntax = (code, filename) => new vm.Script(code, {filename});
+
+/**
+ * Applies the patch to the plugin source code downloaded from upstream.
+ *
+ * @param {string} source_plugin_js - Plugin source code from upstream.
+ * @param {Object<string, string>} source_meta - Metadata parsed from that source code.
+ * @param {Object<string, *>} patch - Patch as returned by read_patch().
+ * @return {?string} Patched source code, or null when the patch no longer applies.
+ */
+const patch_plugin = (source_plugin_js, source_meta, patch) => {
+    const {code, applied} = apply_patch(source_plugin_js, patch);
+    if (!applied) {
+        warn_patch(patch, `does not apply to version ${source_meta.version} anymore, the plugin is published unpatched`);
+        return null;
+    }
+
+    if (JSON.stringify(parseMeta(code)) !== JSON.stringify(source_meta)) {
+        throw new Error(`${patch.path} must not change the ==UserScript== block, use the metadata file for that`);
+    }
+    assert_valid_syntax(code, patch.path);
+
+    if (source_meta.version !== patch.headers.createdForVersion) {
+        warn_patch(patch,
+            `was created for version ${patch.headers.createdForVersion} `+
+            `and still applies to ${source_meta.version}, check whether it is still needed`);
+    }
+
+    return code;
+};
+
 export const update_plugin = async (metadata, author, filename) => {
     const downloaded_plugin_js = await fetchData(metadata.downloadURL);
     if (downloaded_plugin_js === null) throw new Error(`${metadata.downloadURL} is not a valid URL`);
@@ -282,6 +322,9 @@ export const update_plugin = async (metadata, author, filename) => {
     const source_plugin_js = normalize_eol(downloaded_plugin_js);
     const source_meta = parseMeta(source_plugin_js);
     if (source_meta === null) throw new Error(`${metadata.downloadURL} is not a valid metadata file`);
+
+    const patch = read_patch(author, filename);
+    const patched_plugin_js = patch !== null ? patch_plugin(source_plugin_js, source_meta, patch) : null;
 
     const meta = {...{author}, ...source_meta, ...metadata, ...replace_update_url(author, filename)};
     if (meta.skipMatchCheck !== true && !checkMetaMatchPattern(meta)) throw new Error(`Not a valid match pattern in ${meta.match} and ${meta.include}`);
@@ -302,8 +345,13 @@ export const update_plugin = async (metadata, author, filename) => {
         }
     }
 
+    if (patched_plugin_js !== null) {
+        if (source_meta.version !== undefined) meta.version = patched_version(source_meta.version, patch);
+        meta.patch = patch.headers.reason;
+    }
+
     const meta_js = prepare_meta_js(meta);
-    let plugin_js = source_plugin_js.replace(METABLOCK_RE_HEADER, '\n'+meta_js);
+    let plugin_js = (patched_plugin_js ?? source_plugin_js).replace(METABLOCK_RE_HEADER, () => '\n'+meta_js);
     plugin_js = remove_first_line(plugin_js);
 
     await fs.promises.mkdir(`../dist/${author}`, {recursive: true});

--- a/tools/helpers.js
+++ b/tools/helpers.js
@@ -95,6 +95,7 @@ export const normalize_eol = (plugin_js) => plugin_js.replace(/\r\n?/g, '\n');
 const PATCH_HEADER_RE = /^#\s*([A-Za-z][A-Za-z-]*)\s*:\s*(.*)$/;
 const PATCH_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})Z?$/;
 const REQUIRED_PATCH_HEADERS = {reason: 'Reason', createdForVersion: 'Created-For-Version', patchDate: 'Patch-Date'};
+const PATCHES_BASE_URL = 'https://github.com/IITC-CE/Community-plugins/blob/master/patches/';
 
 /**
  * Warnings collected while applying patches, as {path, message} objects.
@@ -469,7 +470,7 @@ export const get_dist_plugins = async () => {
     const dirty_files = get_dirty_dist_files();
     const community_plugins_ids = [];
     const plugins = [];
-    for (const [filepath, ,] of files) {
+    for (const [filepath, author, dist_filename] of files) {
         const metajs = fs.readFileSync(filepath, 'utf8');
 
         const meta = parseMeta(metajs);
@@ -477,6 +478,9 @@ export const get_dist_plugins = async () => {
             if (meta[mergeKey] !== undefined) {
                 meta[mergeKey] = meta[mergeKey].split('|');
             }
+        }
+        if (meta.patch !== undefined) {
+            meta.patchURL = `${PATCHES_BASE_URL}${author}/${dist_filename.replace(/\.meta\.js$/, '.patch')}`;
         }
         meta.description = remove_brackets(meta.description || "");
         meta.id_hash = meta.id.replace("@", "-by-");

--- a/tools/make-patch.js
+++ b/tools/make-patch.js
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import {applyPatch, createTwoFilesPatch} from 'diff';
+import {fetchData, parseMeta} from 'lib-iitc-manager';
+import {apply_patch, normalize_eol, parse_patch, read_metadata_file, read_patch} from './helpers.js';
+
+const fail = (message) => {
+    console.error(message);
+    process.exit(1);
+};
+
+const usage = () => fail([
+    'Usage: npm run patch:start -- <author>/<plugin>',
+    '       npm run patch:save -- <author>/<plugin> --reason="why the patch is needed" [--upstream=<issue url>]'
+].join('\n'));
+
+const [command, target, ...flags] = process.argv.slice(2);
+if (!['start', 'save'].includes(command) || target === undefined || !target.includes('/')) usage();
+
+const flag = (key) => {
+    const found = flags.find((arg) => arg.startsWith(`--${key}=`));
+    return found === undefined ? undefined : found.slice(key.length + 3);
+};
+
+const [author, name] = target.split('/');
+const filename = `${name}.yml`;
+const metadata_path = `../metadata/${author}/${filename}`;
+const metadata = read_metadata_file(metadata_path);
+if (metadata === null) fail(`${metadata_path} does not exist`);
+
+const work_dir = `../patches/.work/${author}/${name}`;
+const pristine_path = `${work_dir}/a.user.js`;
+const edited_path = `${work_dir}/b.user.js`;
+
+if (command === 'start') {
+    const downloaded = await fetchData(metadata.downloadURL);
+    if (downloaded === null) fail(`${metadata.downloadURL} is not a valid URL`);
+
+    const source = normalize_eol(downloaded);
+    const patch = read_patch(author, filename);
+    const {code, applied} = patch === null ? {code: source, applied: false} : apply_patch(source, patch);
+
+    fs.mkdirSync(work_dir, {recursive: true});
+    fs.writeFileSync(pristine_path, source);
+    fs.writeFileSync(edited_path, code);
+
+    console.log(`Downloaded ${metadata.downloadURL}`);
+    if (patch !== null) {
+        console.log(applied
+            ? 'The current patch is already applied to it'
+            : 'The current patch does not apply anymore and was left out, it has to be made again');
+    }
+    console.log(`Now edit ${edited_path} and run:`);
+    console.log(`  npm run patch:save -- ${target} --reason="why the patch is needed"`);
+} else {
+    if (!fs.existsSync(edited_path)) fail(`${edited_path} does not exist, run "npm run patch:start -- ${target}" first`);
+
+    const pristine = normalize_eol(fs.readFileSync(pristine_path, 'utf8'));
+    const edited = normalize_eol(fs.readFileSync(edited_path, 'utf8'));
+    if (pristine === edited) fail(`${edited_path} is unchanged, there is nothing to save`);
+
+    const source_meta = parseMeta(pristine);
+    if (source_meta === null || source_meta.version === undefined) fail(`${pristine_path} has no version in its ==UserScript== block`);
+    if (JSON.stringify(parseMeta(edited)) !== JSON.stringify(source_meta)) {
+        fail(`${edited_path} changes the ==UserScript== block, use ${metadata_path} for that`);
+    }
+
+    const previous = read_patch(author, filename);
+    const reason = flag('reason') ?? previous?.headers.reason;
+    const upstream = flag('upstream') ?? previous?.headers.upstream;
+    if (reason === undefined) fail('--reason="why the patch is needed" is required');
+
+    const preamble = [`# Reason: ${reason}`];
+    if (upstream !== undefined) preamble.push(`# Upstream: ${upstream}`);
+    preamble.push(`# Created-For-Version: ${source_meta.version}`);
+    preamble.push(`# Patch-Date: ${new Date().toISOString().replace('T', ' ').slice(0, 19)}`);
+
+    const diff = createTwoFilesPatch(`a/${name}.user.js`, `b/${name}.user.js`, pristine, edited).replace(/^=+\n/, '');
+    const text = `${preamble.join('\n')}\n${diff}`;
+
+    const patch = parse_patch(text);
+    if (applyPatch(pristine, patch.diff, {fuzzFactor: 0}) !== edited) fail('the generated patch does not reproduce the edited file');
+
+    fs.mkdirSync(`../patches/${author}`, {recursive: true});
+    fs.writeFileSync(`../patches/${author}/${name}.patch`, text);
+    fs.rmSync(work_dir, {recursive: true, force: true});
+
+    console.log(`Wrote patches/${author}/${name}.patch`);
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -8,6 +8,8 @@
     "update-all": "node update-all.js",
     "check-pr": "node check-pr.js",
     "check-updates": "node check-updates.js",
+    "patch:start": "node make-patch.js start",
+    "patch:save": "node make-patch.js save",
     "test": "node --test"
   },
   "dependencies": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -7,9 +7,11 @@
   "scripts": {
     "update-all": "node update-all.js",
     "check-pr": "node check-pr.js",
-    "check-updates": "node check-updates.js"
+    "check-updates": "node check-updates.js",
+    "test": "node --test"
   },
   "dependencies": {
+    "diff": "^9.0.0",
     "lib-iitc-manager": "^2.2.0",
     "node-fetch": "^3.3.2",
     "nunjucks": "^3.2.4",

--- a/tools/patches.test.js
+++ b/tools/patches.test.js
@@ -1,0 +1,116 @@
+import {test} from 'node:test';
+import assert from 'node:assert/strict';
+import {createTwoFilesPatch} from 'diff';
+import {apply_patch, parse_patch, patch_stamp, patched_version} from './helpers.js';
+
+const PREAMBLE = [
+    '# Reason: jQuery 4 removed $.trim()',
+    '# Upstream: https://example.com/issues/1',
+    '# Created-For-Version: 0.1.1.20200216.174029',
+    '# Patch-Date: 2026-07-26 14:30:00'
+].join('\n');
+
+const DIFF = [
+    '--- a/demo.user.js',
+    '+++ b/demo.user.js',
+    '@@ -1,3 +1,3 @@',
+    ' first',
+    '-second',
+    '+patched',
+    ' third',
+    ''
+].join('\n');
+
+const patch_text = (preamble = PREAMBLE, diff = DIFF) => `${preamble}\n${diff}`;
+
+const SOURCE = [
+    '// ==UserScript==',
+    '// @name            Demo',
+    '// @version         0.1.0',
+    '// ==/UserScript==',
+    '',
+    'function demo(value) {',
+    '    var msg = $.trim(value);',
+    '    return msg;',
+    '}',
+    ''
+].join('\n');
+
+const PATCHED_SOURCE = SOURCE.replace('$.trim(value)', "(value || '').trim()");
+
+const demo_patch = () => parse_patch(patch_text(PREAMBLE, createTwoFilesPatch('a/demo.user.js', 'b/demo.user.js', SOURCE, PATCHED_SOURCE)));
+
+test('parse_patch reads the preamble and separates it from the diff', () => {
+    const patch = parse_patch(patch_text());
+
+    assert.deepEqual(patch.headers, {
+        reason: 'jQuery 4 removed $.trim()',
+        upstream: 'https://example.com/issues/1',
+        createdForVersion: '0.1.1.20200216.174029',
+        patchDate: '2026-07-26 14:30:00'
+    });
+    assert.equal(patch.diff, DIFF);
+});
+
+test('parse_patch requires Reason, Created-For-Version and Patch-Date', () => {
+    const lines = PREAMBLE.split('\n');
+    for (const [index, name] of [[0, 'Reason'], [2, 'Created-For-Version'], [3, 'Patch-Date']]) {
+        const preamble = lines.filter((_, i) => i !== index).join('\n');
+        assert.throws(() => parse_patch(patch_text(preamble)), new RegExp(`missing the required "${name}" header`));
+    }
+});
+
+test('parse_patch keeps the Upstream header optional', () => {
+    const preamble = PREAMBLE.split('\n').filter((line) => !line.startsWith('# Upstream')).join('\n');
+    assert.equal(parse_patch(patch_text(preamble)).headers.upstream, undefined);
+});
+
+test('parse_patch rejects a patch without a diff or without hunks', () => {
+    assert.throws(() => parse_patch(PREAMBLE), /missing a "--- " line/);
+    assert.throws(() => parse_patch(patch_text(PREAMBLE, '--- a/demo.user.js\n+++ b/demo.user.js\n')), /the diff is empty/);
+});
+
+test('patch_stamp turns Patch-Date into a numeric version suffix', () => {
+    assert.equal(patch_stamp({patchDate: '2026-07-26 14:30:00'}), '20260726.143000');
+    assert.equal(patch_stamp({patchDate: '2026-07-26T14:30:00Z'}), '20260726.143000');
+
+    for (const patchDate of ['2026-07-26', '26.07.2026 14:30:00', 'yesterday', undefined]) {
+        assert.throws(() => patch_stamp({patchDate: patchDate}), /invalid Patch-Date/);
+    }
+});
+
+test('patched_version appends the stamp only for patched plugins', () => {
+    const patch = parse_patch(patch_text());
+
+    assert.equal(patched_version('0.1.1.20200216.174029', patch), '0.1.1.20200216.174029.20260726.143000');
+    assert.equal(patched_version('0.1.1.20200216.174029', null), '0.1.1.20200216.174029');
+});
+
+test('patched_version leaves plugins without an upstream version alone', () => {
+    const patch = parse_patch(patch_text());
+
+    assert.equal(patched_version(undefined, patch), undefined);
+    assert.equal(patched_version('', patch), '');
+});
+
+test('apply_patch patches the source code', () => {
+    const result = apply_patch(SOURCE, demo_patch());
+
+    assert.equal(result.applied, true);
+    assert.equal(result.code, PATCHED_SOURCE);
+});
+
+test('apply_patch tolerates the patched code moving to another line', () => {
+    const result = apply_patch(`// a new comment from upstream\n${SOURCE}`, demo_patch());
+
+    assert.equal(result.applied, true);
+    assert.equal(result.code, `// a new comment from upstream\n${PATCHED_SOURCE}`);
+});
+
+test('apply_patch reports failure and keeps the source when upstream changed the context', () => {
+    const source = SOURCE.replace('return msg;', 'return msg.toUpperCase();');
+    const result = apply_patch(source, demo_patch());
+
+    assert.equal(result.applied, false);
+    assert.equal(result.code, source);
+});

--- a/tools/templates/README.njk
+++ b/tools/templates/README.njk
@@ -25,6 +25,9 @@ See the [Contributing](CONTRIBUTING.md) documentation.
 {% if plugin.antiFeatures -%}
     **Anti-features:** {% for antiFeature in plugin.antiFeatures %}**[{{ antiFeature }}](/CONTRIBUTING.md#anti-features)** {% endfor %}
 {%- endif %}
+{%- if plugin.patch %}
+**[Patched](/CONTRIBUTING.md#patches) by IITC Community plugins:** {{ plugin.patch }} ([patch]({{ plugin.patchURL }}))
+{%- endif %}
 
 {% if plugin.preview -%}
     ![preview]({{ plugin.preview }})


### PR DESCRIPTION
Adds a mechanism to patch plugin source before publishing, for cases where a small fix is needed (compatibility issues, small bugs) - not for adding functionality.
A patch is a diff in `patches/<author>/<plugin>.patch`; it stops applying if upstream changes the patched code, so the plugin still gets published (unpatched, with a warning) instead of silently breaking.

Patched plugins are republished under `<upstream version>.<patch date>` so userscript managers pick up the update, and show up as patched in `dist/meta.json`, README.md and PR comments.
`patch:start` / `patch:save` npm scripts create and update a patch without hand-editing diffs.