### PR TITLE
Add Ops Route Planner plugin

### DIFF
--- a/metadata/robertclemo/route-planner.yml
+++ b/metadata/robertclemo/route-planner.yml
@@ -1,0 +1,5 @@
+updateURL: https://raw.githubusercontent.com/robertclemo/route-planner-iitc/main/route-planner.user.js
+downloadURL: https://raw.githubusercontent.com/robertclemo/route-planner-iitc/main/route-planner.user.js
+homepageURL: https://github.com/robertclemo/route-planner-iitc
+depends:
+  - draw-tools@breunigs


### PR DESCRIPTION
Adds metadata for `route-planner@robertclemo` — draws a shape with Draw Tools and computes an optimized round-trip driving route through every portal inside it.

- Hosted at https://github.com/robertclemo/route-planner-iitc
- Depends on `draw-tools@breunigs`
- Validated locally that the metadata builds correctly (id, homepageURL, issueTracker auto-derived as expected)