### PR TITLE
Add Anchor Route Planner plugin

### DIFF
--- a/metadata/robertclemo/anchor-route-planner.yml
+++ b/metadata/robertclemo/anchor-route-planner.yml
@@ -1,0 +1,5 @@
+updateURL: https://raw.githubusercontent.com/robertclemo/ingress-plugins/main/anchor-route-planner/anchor-route-planner.user.js
+downloadURL: https://raw.githubusercontent.com/robertclemo/ingress-plugins/main/anchor-route-planner/anchor-route-planner.user.js
+homepageURL: https://github.com/robertclemo/ingress-plugins
+depends:
+  - draw-tools@breunigs


### PR DESCRIPTION
Adds a new plugin, **Anchor Route Planner** (`anchor-route-planner@robert`), to the catalog.

Mark individual anchor portals with Draw Tools (place a marker on each, or draw a polygon whose corners sit on the anchors), then get the fastest real driving/walking route stitching them together, in the best order.

- Requires Draw Tools (`depends: draw-tools@breunigs`)
- Source: https://github.com/robertclemo/ingress-plugins/tree/main/anchor-route-planner

Note for reviewers: for real road routing the plugin sends the marked anchor points' coordinates to the public OSRM routing APIs (`router.project-osrm.org` for driving, `routing.openstreetmap.de` for walking), falling back to a local straight-line estimate if that request fails. No Niantic/Ingress account or portal-ownership data is sent — just the lat/lng points the player marked, same information already used to build the Google Maps directions link. Flagging this here in case it should be called out under `antiFeatures`.